### PR TITLE
Allow pass token as param for complete purchase

### DIFF
--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -23,7 +23,12 @@ class CompletePurchaseRequest extends PurchaseRequest
             'authenticationCode'
         );
 
-        $token = $this->httpRequest->query->get('token');
+        $token = $this->getToken();
+
+        if (!$token) {
+            $token = $this->httpRequest->query->get('token');
+        }
+
         if (!$token) {
             //this may be a POST nudge request, so look for the token there
             $token = $this->httpRequest->request->get('Token');
@@ -51,5 +56,10 @@ class CompletePurchaseRequest extends PurchaseRequest
         $httpResponse = $request->send();
 
         return $this->response = new CompletePurchaseResponse($this, $httpResponse->getBody());
+    }
+
+    public function getToken()
+    {
+        return $this->getParameter('token');
     }
 }


### PR DESCRIPTION
This enables the complete purchase request to accept a parameter `token`. It is useful when we did not receive the notifications from POLi and we can **notify** by ourself in the crontab.

$proxy->completePurchase(['token' => $token])->send();
