### PR TITLE
Fixed transaction token in FetchCheckoutRequest

### DIFF
--- a/src/Message/FetchCheckoutRequest.php
+++ b/src/Message/FetchCheckoutRequest.php
@@ -47,7 +47,7 @@ class FetchCheckoutRequest extends AbstractRequest
 
     public function sendData($data): RedirectResponseInterface
     {
-        $token = $this->httpRequest->query->get('token');
+        $token = $this->getParameter('token');
         $url = $this->endpoint . '?token=' . urlencode($token);
 
         $merchantCode = $this->getMerchantCode();


### PR DESCRIPTION
The transaction token was not being fetched correctly and so the request would fail.
This change fixes it.