### PR TITLE
set request method as capital `POST`

### DIFF
--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -60,7 +60,7 @@ class CompletePurchaseRequest extends PurchaseRequest
         $url = $this->getEndpoint() . '?' . http_build_query($data);
 
         $httpResponse = $this->httpClient
-            ->request('get', $url, $headers, http_build_query($data));
+            ->request('GET', $url, $headers, http_build_query($data));
 
         return $this->response = new CompletePurchaseResponse($this, $httpResponse->getBody());
     }

--- a/src/Message/FetchCheckoutRequest.php
+++ b/src/Message/FetchCheckoutRequest.php
@@ -55,7 +55,7 @@ class FetchCheckoutRequest extends AbstractRequest
         $auth = base64_encode($merchantCode . ":" . $authenticationCode); //'S61xxxxx:AuthCode123');
 
         $httpResponse = $this->httpClient->request(
-            'get',
+            'GET',
             $url,
             array(
                 'Content-Type' => 'application/json',

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -144,7 +144,7 @@ class PurchaseRequest extends AbstractRequest
 
         $postdata = json_encode($data);
         $httpResponse = $this->httpClient->request(
-            'post',
+            'POST',
             $this->getEndpoint(),
             array(
                 'Content-Type' => 'application/json',


### PR DESCRIPTION
POLi is now rejecting lower case request methods, because ... reasons I guess?  

`Invalid HTTP method "post", only uppercase letters are accepted.`